### PR TITLE
use the same version as the evm and chain-evm crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ include = [ "/evm-tests" ]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.74" }
-primitive-types = { version = "0.10.1" }
+primitive-types = { version = ">= 0.10, <= 0.11" }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Updates the version of `primitive-types` to be the same as the one in `evm` and `chain-evm`.